### PR TITLE
Fix Mono and Document font in Cinnamon

### DIFF
--- a/debian/ubuntucinnamon-environment.gsettings-override
+++ b/debian/ubuntucinnamon-environment.gsettings-override
@@ -21,10 +21,35 @@ home-icon-visible=true
 trash-icon-visible=true
 volumes-visible=true
 desktop-layout='true:true'
+use-desktop-grid=true
 font='Ubuntu 11'
+
 
 [org.nemo.preferences]
 size-prefixes='binary'
+image-viewers-with-external-sort=['shotwell', 'eog', 'xviewer', 'feh', 'sxiv']
+sort-directories-first=true
+sort-favorites-first=true
+show-list-view-icon-toolbar=true
+show-location-entry=true
+show-image-thumbnails='local-only'
+thumbnail-limit=uint64 4294967295
+
+#Gedit settings
+[org.gnome.gedit.preferences.editor]
+auto-indent=true
+bracket-matching=true
+display-line-numbers=true
+display-overview-map=true
+display-right-margin=true
+highlight-current-line=true
+scheme='oblivion'
+search-highlighting=true
+syntax-highlighting=true
+tabs-size=uint32 4
+use-default-font=true
+ensure-trailing-newline=true
+max-undo-actions=2000
 
 [org.nemo.window-state]
 sidebar-width=200

--- a/debian/ubuntucinnamon-environment.gsettings-override
+++ b/debian/ubuntucinnamon-environment.gsettings-override
@@ -12,6 +12,8 @@ cursor-theme='Yaru-Cinnamon'
 clock-show-date=true
 clock-show-seconds=true
 font-name='Ubuntu 11'
+document-font-name='Ubuntu 11'
+monospace-font-name='Ubuntu Mono 11'
 
 [org.nemo.desktop]
 computer-icon-visible=true


### PR DESCRIPTION
Font names need to be declared both in org.cinnamon.desktop.interface and org.gnome.desktop.interface